### PR TITLE
Fix: Make JS plays nicely with Turbolinks Integration

### DIFF
--- a/app/assets/javascripts/hippocrates.js
+++ b/app/assets/javascripts/hippocrates.js
@@ -9,7 +9,7 @@ if(typeof Hippocrates === "undefined") {
   Hippocrates.Settings = {};
 }
 
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
     Hippocrates.Autocomplete.init();
     Hippocrates.Certificates.init();
     Hippocrates.ClinicalHistory.init();


### PR DESCRIPTION
JavaScript was no executing when the page loads, it requires refreshing the page to execute the scripts. This commit changes the listener `ready` to `turbolinks:load`.

https://github.com/turbolinks/turbolinks/issues/9#issuecomment-184717346