### PR TITLE
Refactor: Update settings semantics

### DIFF
--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -84,6 +84,22 @@ class ConsultationsController < ApplicationController
     @patient = Patient.find(params[:patient_id])
   end
 
+  def remaining_diagnoses
+    maximum_diagnoses - @consultation.diagnoses.count
+  end
+
+  def remaining_prescriptions
+    maximum_prescriptions - @consultation.prescriptions.count
+  end
+
+  def maximum_diagnoses
+    Setting.maximum_diagnoses.value.to_i
+  end
+
+  def maximum_prescriptions
+    Setting.maximum_prescriptions.value.to_i
+  end
+
   def consultation_params
     params.require(:consultation).permit(*ATTRIBUTE_WHITELIST).merge(
       patient_id: params[:patient_id]
@@ -91,22 +107,6 @@ class ConsultationsController < ApplicationController
   end
 
   def patient_params
-    { special: params[:consultation][:patient][:special] }
-  end
-
-  def maximum_diagnoses
-    Setting.maximum_diagnoses
-  end
-
-  def maximum_prescriptions
-    Setting.maximum_prescriptions
-  end
-
-  def remaining_diagnoses
-    maximum_diagnoses - @consultation.diagnoses.count
-  end
-
-  def remaining_prescriptions
-    maximum_prescriptions - @consultation.prescriptions.count
+    { special: params.dig(:consultation, :patient, :special) }
   end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,7 +1,7 @@
 class SettingsController < ApplicationController
   def index
-    @maximum_diagnoses        = Setting.find_by(name: Setting::MAXIMUM_DIAGNOSES)
-    @maximum_prescriptions    = Setting.find_by(name: Setting::MAXIMUM_PRESCRIPTIONS)
-    @medical_history_sequence = Setting.find_by(name: Setting::MEDICAL_HISTORY_SEQUENCE)
+    @maximum_diagnoses        = Setting.maximum_diagnoses
+    @maximum_prescriptions    = Setting.maximum_prescriptions
+    @medical_history_sequence = Setting.medical_history_sequence
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,30 +8,35 @@ class Setting < ActiveRecord::Base
   validates_numericality_of :value, only_integer: true
 
   def self.maximum_diagnoses
-    setting = find_by(name: MAXIMUM_DIAGNOSES)
-    return setting.value.to_i if setting
-
-    raise SettingNotFoundError, 'maximun diagnoses value is not available'
+    find_or_fail!(MAXIMUM_DIAGNOSES)
   end
 
   def self.maximum_prescriptions
-    setting = find_by(name: MAXIMUM_PRESCRIPTIONS)
-    return setting.value.to_i if setting
+    find_or_fail!(MAXIMUM_PRESCRIPTIONS)
+  end
 
-    raise SettingNotFoundError, 'maximun prescription value is not available'
+  def self.medical_history_sequence
+    find_or_fail!(MEDICAL_HISTORY_SEQUENCE)
   end
 
   class MedicalHistorySequence
     def self.next
-      setting = Setting.find_by(name: MEDICAL_HISTORY_SEQUENCE)
-      setting.value.to_i.succ
+      Setting.medical_history_sequence.value.to_i.succ
     end
 
     def save
-      setting = Setting.find_by(name: MEDICAL_HISTORY_SEQUENCE)
+      setting = Setting.medical_history_sequence
       setting.value = setting.value.to_i.succ.to_s
       setting.save
     end
+  end
+
+  private_class_method
+
+  def self.find_or_fail!(setting_name)
+    find_by!(name: setting_name)
+  rescue ActiveRecord::RecordNotFound
+    raise SettingNotFoundError, "#{setting_name} is not available"
   end
 end
 

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -10,36 +10,25 @@ describe Setting do
     it { is_expected.to validate_numericality_of(:value).only_integer }
   end
 
-  describe '.maximum_diagnoses' do
-    context 'when setting is present' do
-      it 'returns maximum diagnoses value' do
-        described_class.create(name: Setting::MAXIMUM_DIAGNOSES, value: '4')
-        expect(described_class.maximum_diagnoses).to eq(4)
-      end
-    end
+  [
+    Setting::MAXIMUM_DIAGNOSES,
+    Setting::MAXIMUM_PRESCRIPTIONS,
+    Setting::MEDICAL_HISTORY_SEQUENCE
+  ].each do |setting_name|
+    describe ".#{setting_name}" do
+      subject { described_class.public_send(setting_name.to_sym) }
 
-    context 'when setting is not present' do
-      it 'raises an error' do
-        expect do
-          described_class.maximum_diagnoses
-        end.to raise_error(SettingNotFoundError)
+      context 'when the setting is present' do
+        it 'returns the setting' do
+          setting = described_class.create(name: setting_name, value: '2')
+          expect(subject).to eq(setting)
+        end
       end
-    end
-  end
 
-  describe '.maximum_prescriptions' do
-    context 'when setting is present' do
-      it 'returns maximum prescriptions value' do
-        described_class.create(name: Setting::MAXIMUM_PRESCRIPTIONS, value: '5')
-        expect(described_class.maximum_prescriptions).to eq(5)
-      end
-    end
-
-    context 'when setting is not present' do
-      it 'raises an error' do
-        expect do
-          described_class.maximum_prescriptions
-        end.to raise_error(SettingNotFoundError)
+      context 'when setting is not present' do
+        it 'raises an error' do
+          expect { subject }.to raise_error(SettingNotFoundError)
+        end
       end
     end
   end


### PR DESCRIPTION
The methods of the Setting model was used in both, the settings controller and the consultation controller. Their usage was similar but it has duplication. This commit gets rid of that duplication by adding a more appropriate level of abstraction.