### PR TITLE
Fix: Disable Turbolinks for download links

### DIFF
--- a/app/assets/javascripts/clinical_history.js
+++ b/app/assets/javascripts/clinical_history.js
@@ -24,6 +24,7 @@ Hippocrates.ClinicalHistory = {
         url: "/api/patients/" + patientId + "/consultations/destroy",
         type: "DELETE",
         data: { consultations: consultations },
+        dataType: "script",
         success: function(data) {
           location.reload();
         }

--- a/app/views/consultations/_modal_certificates.haml
+++ b/app/views/consultations/_modal_certificates.haml
@@ -65,4 +65,7 @@
                 %em.text-muted Costo de la cirugía (en dólares)
       .modal-footer
         %button.btn.btn-default{ "data-dismiss": "modal" } Cerrar
-        = link_to "Descargar certificado", download_certificates_path(consultation_id: @consultation.id, certificate_type: "simple"), class: 'btn btn-primary'
+        = link_to t('certificates.button.download'),
+          download_certificates_path(consultation_id: @consultation.id, certificate_type: "simple"),
+          class: 'btn btn-primary',
+          data: { turbolinks: false }

--- a/app/views/consultations/index.haml
+++ b/app/views/consultations/index.haml
@@ -31,7 +31,7 @@
     %a.delete-consultations.btn.btn-danger(href = "")
       %i.fa.fa-trash
       Eliminar
-    %a.download-medical-history.btn.btn-primary(href = "#")
+    %a.download-medical-history.btn.btn-primary{ href: "#", "data-turbolinks": "false" }
       %i.fa.fa-download
       Descargar
     = link_to new_patient_consultation_path(@patient), class: "btn btn-success" do
@@ -125,9 +125,12 @@
                   %span.caret
               %ul.dropdown-menu.pull-right
                 %li
-                  = link_to "Editar", edit_patient_consultation_path(@patient, consultation)
+                  = link_to "Editar",
+                    edit_patient_consultation_path(@patient, consultation)
                 %li
-                  = link_to "Descargar certificado", download_certificates_path(consultation_id: consultation.id, certificate_type: "consultation")
+                  = link_to t('certificates.button.download'),
+                    download_certificates_path(consultation_id: consultation.id, certificate_type: "consultation"),
+                    data: { turbolinks: false }
 
 .row
   .col-md-12.text-center

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,3 +68,6 @@ en:
     success:
       creation: Consultation created successfully
       update: Consultation updated successfully
+  certificates:
+    button:
+      download: Download certificate

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -68,6 +68,9 @@ es:
     success:
       creation: Consulta creada correctamente
       update: Consulta actualizada correctamente
+  certificates:
+    button:
+      download: Descargar certificado
 
   activerecord:
     errors:


### PR DESCRIPTION
Turbolinks doesn't play well with `send_data`. Without disable them, they try to render the attached content instead of downloading it.