### PR TITLE
Refactor: Reduce duplication from models

### DIFF
--- a/app/models/anamnesis.rb
+++ b/app/models/anamnesis.rb
@@ -1,7 +1,7 @@
 class Anamnesis < ApplicationRecord
   belongs_to :patient
 
-  before_save :normalize_values
+  before_save :normalize
 
   def allergies?
     allergies.present?
@@ -17,12 +17,12 @@ class Anamnesis < ApplicationRecord
 
   private
 
-  def normalize_values
-    %w[medical_history surgical_history allergies observations habits
-       family_history].each do |field|
-      if attributes[field].present?
-        send("#{field}=", UnicodeUtils.upcase(attributes[field]))
-      end
-    end
+  def normalize
+    normalize_fields :medical_history,
+                     :surgical_history,
+                     :allergies,
+                     :observations,
+                     :habits,
+                     :family_history
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,11 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def normalize_fields(*fields)
+    fields.map(&:to_s).each do |field|
+      if attributes[field].present?
+        public_send("#{field}=", UnicodeUtils.upcase(attributes[field]))
+      end
+    end
+  end
 end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -11,7 +11,7 @@ class Consultation < ApplicationRecord
                                 reject_if: ->(attributes) { attributes[:inscription].blank? },
                                 allow_destroy: true
 
-  before_save :normalize_values
+  before_save :normalize
 
   default_scope { order(created_at: :desc) }
 
@@ -54,15 +54,28 @@ class Consultation < ApplicationRecord
 
   private
 
-  def normalize_values
-    %w[reason ongoing_issue organs_examination physical_examination
-       right_ear left_ear right_nostril left_nostril nasopharynx
-       nose_others oral_cavity oropharynx hypopharynx larynx
-       neck others miscellaneous diagnostic_plan treatment_plan
-       educational_plan hearing_aids].each do |field|
-      if attributes[field].present?
-        send("#{field}=", UnicodeUtils.upcase(attributes[field]))
-      end
-    end
+  # rubocop:disable MethodLength
+  def normalize
+    normalize_fields :reason,
+                     :ongoing_issue,
+                     :organs_examination,
+                     :physical_examination,
+                     :right_ear,
+                     :left_ear,
+                     :right_nostril,
+                     :left_nostril,
+                     :nasopharynx,
+                     :nose_others,
+                     :oral_cavity,
+                     :oropharynx,
+                     :hypopharynx,
+                     :larynx,
+                     :neck,
+                     :others,
+                     :miscellaneous,
+                     :diagnostic_plan,
+                     :treatment_plan,
+                     :educational_plan,
+                     :hearing_aids
   end
 end

--- a/app/models/disease.rb
+++ b/app/models/disease.rb
@@ -4,7 +4,7 @@ class Disease < ApplicationRecord
   validates_presence_of :code, :name
   validates_uniqueness_of :code
 
-  before_save :normalize_values
+  before_save :normalize
 
   def self.search(query)
     if query
@@ -17,11 +17,7 @@ class Disease < ApplicationRecord
 
   private
 
-  def normalize_values
-    %w[code name].each do |field|
-      if attributes[field].present?
-        send("#{field}=", UnicodeUtils.upcase(attributes[field]))
-      end
-    end
+  def normalize
+    normalize_fields :code, :name
   end
 end

--- a/app/models/medicine.rb
+++ b/app/models/medicine.rb
@@ -4,7 +4,7 @@ class Medicine < ApplicationRecord
 
   validates :name, uniqueness: true
 
-  before_save :normalize_values
+  before_save :normalize
 
   def self.search(query)
     if query
@@ -17,11 +17,7 @@ class Medicine < ApplicationRecord
 
   private
 
-  def normalize_values
-    %w[name instructions].each do |field|
-      if attributes[field].present?
-        send("#{field}=", UnicodeUtils.upcase(attributes[field]))
-      end
-    end
+  def normalize
+    normalize_fields :name, :instructions
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -19,7 +19,7 @@ class Patient < ApplicationRecord
             :identity_card_number, uniqueness: true
   validates :email, uniqueness: true, allow_nil: true, allow_blank: true
 
-  before_save :normalize_values
+  before_save :normalize
 
   scope :special, -> { where(special: true) }
 
@@ -51,13 +51,11 @@ class Patient < ApplicationRecord
 
   private
 
-  def normalize_values
-    %w[last_name first_name address profession].each do |field|
-      if attributes[field].present?
-        send("#{field}=", UnicodeUtils.upcase(attributes[field]))
-      end
-    end
-
+  def normalize
+    normalize_fields :last_name,
+                     :first_name,
+                     :address,
+                     :profession
     email.downcase! if email.present?
   end
 end

--- a/spec/models/disease_spec.rb
+++ b/spec/models/disease_spec.rb
@@ -11,7 +11,7 @@ describe Disease do
 
   describe 'normalize attributes' do
     it 'upcases the attributes' do
-      disease = create(:disease, code: 'A002', name: 'rhinitis')
+      disease = create(:disease, name: 'rhinitis')
       expect(disease.name).to eq('RHINITIS')
     end
   end


### PR DESCRIPTION
Most of the models use the same normalization logic. This commit extracts out that logic into the method `normalize_fields`. Using this new method serves to reduce duplication.