### PR TITLE
Refactor: Move presentation methods from models to presenters

### DIFF
--- a/app/controllers/anamneses_controller.rb
+++ b/app/controllers/anamneses_controller.rb
@@ -8,8 +8,9 @@ class AnamnesesController < ApplicationController
     :family_history
   ].freeze
 
+  before_action :fetch_patient, only: [:new, :edit]
+
   def new
-    @patient   = Patient.find(params[:patient_id])
     @anamnesis = Anamnesis.new
   end
 
@@ -22,7 +23,6 @@ class AnamnesesController < ApplicationController
   end
 
   def edit
-    @patient   = Patient.find(params[:patient_id])
     @anamnesis = Anamnesis.find(params[:id])
     @referer_location = referer_location
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def fetch_patient
+    @patient = PatientPresenter.new(Patient.find(params[:patient_id]))
+  end
+
   def page
     params.fetch(:page, 1)
   end

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsultationsController < ApplicationController
   ATTRIBUTE_WHITELIST = [
     :reason,
@@ -38,7 +40,9 @@ class ConsultationsController < ApplicationController
 
   def index
     delete_referer_location
-    @consultations = @patient.consultations.page(params.fetch(:page, 1))
+    @consultations = ConsultationsPresenter.new(
+      @patient.consultations.page(params.fetch(:page, 1))
+    )
   end
 
   def new
@@ -78,7 +82,7 @@ class ConsultationsController < ApplicationController
   private
 
   def fetch_consultation
-    @consultation = Consultation.find(params[:id])
+    @consultation = ConsultationPresenter.new(Consultation.find(params[:id]))
   end
 
   def remaining_diagnoses

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -81,10 +81,6 @@ class ConsultationsController < ApplicationController
     @consultation = Consultation.find(params[:id])
   end
 
-  def fetch_patient
-    @patient = Patient.find(params[:patient_id])
-  end
-
   def remaining_diagnoses
     maximum_diagnoses - @consultation.diagnoses.count
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -32,26 +32,6 @@ class Consultation < ApplicationRecord
     end
   end
 
-  def date
-    self[:created_at].strftime('%Y-%m-%d')
-  end
-
-  def time
-    self[:created_at].strftime('%I:%M %p')
-  end
-
-  def pretty_date
-    I18n.localize(self[:created_at], format: '%B %d de %Y')
-  end
-
-  def miscellaneous?
-    miscellaneous.present?
-  end
-
-  def next_appointment?
-    next_appointment.present?
-  end
-
   private
 
   # rubocop:disable MethodLength

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -33,14 +33,6 @@ class Patient < ApplicationRecord
     end
   end
 
-  def age
-    AgeCalculator.calculate(birthdate)
-  end
-
-  def name
-    "#{last_name} #{first_name}"
-  end
-
   def anamnesis?
     anamnesis.present?
   end

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class ConsultationPresenter < SimpleDelegator
+  def date
+    created_at.strftime('%F')
+  end
+
+  def long_date
+    created_at.strftime('%b %d, %Y')
+  end
+
+  def time
+    created_at.strftime('%I:%M %p')
+  end
+
+  def pretty_date
+    I18n.localize(created_at, format: '%B %d de %Y')
+  end
+
+  def next_appointment_date
+    next_appointment.strftime('%F')
+  end
+
+  def next_appointment_long_date
+    next_appointment.strftime('%b %d, %Y')
+  end
+
+  def next_appointment?
+    next_appointment.present?
+  end
+
+  def diagnoses?
+    diagnoses.count.positive?
+  end
+
+  def prescriptions?
+    prescriptions.count.positive?
+  end
+
+  def miscellaneous?
+    miscellaneous.present?
+  end
+end

--- a/app/presenters/consultations_presenter.rb
+++ b/app/presenters/consultations_presenter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+class ConsultationsPresenter < SimpleDelegator
+  extend Forwardable
+
+  def_delegators :@consultations, :total_pages, :current_page, :limit_value
+
+  def initialize(consultations)
+    @consultations = consultations
+  end
+
+  def each
+    @consultations.each do |consultation|
+      yield ConsultationPresenter.new(consultation)
+    end
+  end
+end

--- a/app/presenters/patient_presenter.rb
+++ b/app/presenters/patient_presenter.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 class PatientPresenter < SimpleDelegator
+  def age
+    AgeCalculator.calculate(birthdate)
+  end
+
   def formatted_birthdate
     if new_record?
       ''
     else
       birthdate.strftime('%F')
     end
+  end
+
+  def name
+    "#{last_name} #{first_name}"
   end
 end

--- a/app/serializers/consultation_serializer.rb
+++ b/app/serializers/consultation_serializer.rb
@@ -34,7 +34,17 @@ class ConsultationSerializer < ActiveModel::Serializer
     attribute :male?, key: :isMale
 
     def name
-      "#{object.last_name} #{object.first_name}"
+      presenter.name
+    end
+
+    def age
+      presenter.age
+    end
+
+    private
+
+    def presenter
+      PatientPresenter.new(object)
     end
   end
 

--- a/app/serializers/consultation_serializer.rb
+++ b/app/serializers/consultation_serializer.rb
@@ -9,24 +9,23 @@ class ConsultationSerializer < ActiveModel::Serializer
   has_many :prescriptions
 
   def diagnoses?
-    object.diagnoses.count.positive?
+    consultation_presenter.diagnoses?
   end
 
   def prescriptions?
-    object.prescriptions.count.positive?
+    consultation_presenter.prescriptions?
   end
 
   def date
-    object.created_at.strftime('%F')
+    consultation_presenter.date
   end
 
   def next_appointment?
-    object.next_appointment.present?
+    consultation_presenter.next_appointment?
   end
 
   def next_appointment
-    return object.next_appointment.strftime('%F') if next_appointment?
-    object.next_appointment
+    return consultation_presenter.next_appointment_date if consultation_presenter.next_appointment?
   end
 
   class PatientSerializer < ActiveModel::Serializer
@@ -34,16 +33,16 @@ class ConsultationSerializer < ActiveModel::Serializer
     attribute :male?, key: :isMale
 
     def name
-      presenter.name
+      patient_presenter.name
     end
 
     def age
-      presenter.age
+      patient_presenter.age
     end
 
     private
 
-    def presenter
+    def patient_presenter
       PatientPresenter.new(object)
     end
   end
@@ -55,5 +54,11 @@ class ConsultationSerializer < ActiveModel::Serializer
 
   class PrescriptionSerializer < ActiveModel::Serializer
     attributes :inscription, :subscription
+  end
+
+  private
+
+  def consultation_presenter
+    ConsultationPresenter.new(object)
   end
 end

--- a/app/views/application/_patient.haml
+++ b/app/views/application/_patient.haml
@@ -10,11 +10,11 @@
             - if (@consultation && @consultation.new_record?) || @anamnesis
               %input.form-control.input-sm.colored#current_date{ disabled: 'disabled', value: Date.today }
             - else
-              %input.form-control.input-sm.colored#current_date{ disabled: 'disabled', value: @consultation.created_at.strftime("%Y-%m-%d") }
+              %input.form-control.input-sm.colored#current_date{ disabled: 'disabled', value: @consultation.date }
         .form-group.col-md-3
           .input-group
             %span.input-group-addon.input-sm Fecha Nacimiento
-            %input.form-control.input-sm.colored{ disabled: 'disabled', value: @patient.birthdate.strftime("%Y-%m-%d") }
+            %input.form-control.input-sm.colored{ disabled: 'disabled', value: @patient.formatted_birthdate }
         .form-group.col-md-3
           .input-group
             %span.input-group-addon.input-sm # Cédula

--- a/app/views/consultations/index.haml
+++ b/app/views/consultations/index.haml
@@ -78,59 +78,59 @@
                 Consultas
           %th.col-sm-2
       %tbody
-      - @consultations.each do |consultation|
-        %tr
-          %td.checkbox-container
-            %input.check-consultation{ type: "checkbox", id: consultation.id }
-          %td
-            .row
-              .col-md-10.col-md-offset-2
-                %strong
-                  %big= consultation.created_at.strftime("%b %d, %Y")
-            - if consultation.reason.present?
+        - @consultations.each do |consultation|
+          %tr
+            %td.checkbox-container
+              %input.check-consultation{ type: "checkbox", id: consultation.id }
+            %td
               .row
-                .col-md-2.text-right.hidden-xs
-                  %span.semi-strong.text-muted Motivo
-                .col-md-2.visible-xs
-                  %span.semi-strong.text-muted Motivo
-                .col-md-10
-                  %span
-                    = consultation.reason
-            - if consultation.miscellaneous.present?
-              .row
-                .col-md-2.text-right.hidden-xs
-                  %span.semi-strong.text-muted Misceláneos
-                .col-md-2.visible-xs
-                  %span.semi-strong.text-muted Misceláneos
-                .col-md-10
-                  %span.semi-strong
-                  = consultation.miscellaneous
-            - if consultation.next_appointment.present?
-              .row
-                .col-md-2.text-right.hidden-xs
-                  %span.semi-strong.text-muted Próxima cita
-                .col-md-2.visible-xs
-                  %span.semi-strong.text-muted Próxima cita
-                .col-md-10
-                  %span.semi-strong
-                  = consultation.next_appointment.strftime("%b %d, %Y")
-          %td.text-right
-            .btn-group
-              %button.btn.btn-default.btn-xs.dropdown-toggle{ "aria-expanded": "false",
-                                                              "aria-haspopup": "true",
-                                                              "data-toggle": "dropdown",
-                                                              "type": "button" }
-                .span.text-primary
-                  %i.fa.fa-cog
-                  %span.caret
-              %ul.dropdown-menu.pull-right
-                %li
-                  = link_to "Editar",
-                    edit_patient_consultation_path(@patient, consultation)
-                %li
-                  = link_to t('certificates.button.download'),
-                    download_certificates_path(consultation_id: consultation.id, certificate_type: "consultation"),
-                    data: { turbolinks: false }
+                .col-md-10.col-md-offset-2
+                  %strong
+                    %big= consultation.long_date
+              - if consultation.reason.present?
+                .row
+                  .col-md-2.text-right.hidden-xs
+                    %span.semi-strong.text-muted Motivo
+                  .col-md-2.visible-xs
+                    %span.semi-strong.text-muted Motivo
+                  .col-md-10
+                    %span
+                      = consultation.reason
+              - if consultation.miscellaneous.present?
+                .row
+                  .col-md-2.text-right.hidden-xs
+                    %span.semi-strong.text-muted Misceláneos
+                  .col-md-2.visible-xs
+                    %span.semi-strong.text-muted Misceláneos
+                  .col-md-10
+                    %span.semi-strong
+                    = consultation.miscellaneous
+              - if consultation.next_appointment.present?
+                .row
+                  .col-md-2.text-right.hidden-xs
+                    %span.semi-strong.text-muted Próxima cita
+                  .col-md-2.visible-xs
+                    %span.semi-strong.text-muted Próxima cita
+                  .col-md-10
+                    %span.semi-strong
+                    = consultation.next_appointment_long_date
+            %td.text-right
+              .btn-group
+                %button.btn.btn-default.btn-xs.dropdown-toggle{ "aria-expanded": "false",
+                                                                "aria-haspopup": "true",
+                                                                "data-toggle": "dropdown",
+                                                                "type": "button" }
+                  .span.text-primary
+                    %i.fa.fa-cog
+                    %span.caret
+                %ul.dropdown-menu.pull-right
+                  %li
+                    = link_to "Editar",
+                      edit_patient_consultation_path(@patient, consultation)
+                  %li
+                    = link_to t('certificates.button.download'),
+                      download_certificates_path(consultation_id: consultation.id, certificate_type: "consultation"),
+                      data: { turbolinks: false }
 
 .row
   .col-md-12.text-center

--- a/app/views/patients/special.haml
+++ b/app/views/patients/special.haml
@@ -28,7 +28,7 @@
             .col-md-12
               %strong
                 %span.text-muted Próxima cita
-              = patient.consultations.most_recent.next_appointment.strftime("%Y-%m-%d")
+              = patient.consultations.most_recent.next_appointment_date
         - if patient.consultations.most_recent.miscellaneous?
           .row
             .col-md-12

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -1,0 +1,12 @@
+Feature: User can manage patient's consultations
+
+  Scenario: Listing consultations
+    Given Ada is a patient with consultations
+    When I go to her consultations page
+    Then I see her consultations
+
+  Scenario: Creating a consultation
+    Given Ada is a patient
+    When I go to create consultation page
+    And I input consultation info
+    Then I see a success message

--- a/features/patients.feature
+++ b/features/patients.feature
@@ -1,5 +1,6 @@
 Feature: User can manage the patients
 
+  # TODO: Reword the expectations, it's too verbose
   Scenario: Listing patients
     Given the following patients exist:
       | first_name | last_name |

--- a/features/step_definitions/consultations_steps.rb
+++ b/features/step_definitions/consultations_steps.rb
@@ -1,0 +1,39 @@
+Given(/^Ada is a patient with consultations$/) do
+  log_in(create(:user))
+  @ada = create(:patient, first_name: 'Ada', last_name: 'Lovelace')
+  create(:consultation, patient: @ada, next_appointment: '2017-09-01')
+end
+
+When(/^I go to her consultations page$/) do
+  visit patient_consultations_path(@ada.id)
+end
+
+Then(/^I see her consultations$/) do
+  within('tbody') do
+    expect(page).to have_content('Sep 01, 2017')
+  end
+end
+
+Given(/^Ada is a patient$/) do
+  log_in(create(:user))
+  @ada = create(:patient_with_anamnesis, first_name: 'Ada', last_name: 'Lovelace')
+
+  create(:setting, :maximum_diagnoses)
+  create(:setting, :maximum_prescriptions)
+  create(:setting, :medical_history_sequence)
+end
+
+When(/^I go to create consultation page$/) do
+  visit new_patient_consultation_path(@ada.id)
+end
+
+When(/^I input consultation info$/) do
+  # TODO: Add additional fields
+  fill_in :consultation_reason, with: 'consultation reason'
+  fill_in :consultation_ongoing_issue, with: 'consultation ongoing issue'
+  click_on 'Guardar'
+end
+
+Then(/^I see a success message$/) do
+  expect(page).to have_content('Consulta creada correctamente')
+end

--- a/features/step_definitions/patients_steps.rb
+++ b/features/step_definitions/patients_steps.rb
@@ -1,8 +1,9 @@
 Given(/^the following patients exist:$/) do |table|
   log_in(create(:user))
   table.hashes.each do |patient|
-    create(:patient,
-           first_name: patient[:first_name], last_name: patient[:last_name])
+    create(
+      :patient, first_name: patient[:first_name], last_name: patient[:last_name]
+    )
   end
 end
 

--- a/lib/certificate.rb
+++ b/lib/certificate.rb
@@ -13,7 +13,7 @@ class Certificate
   def build
     {
       patient: patient,
-      consultation: consultation,
+      consultation: ConsultationPresenter.new(consultation),
       diagnosis: diagnosis,
       definite_article: definite_article,
       current_date: current_date,
@@ -32,7 +32,7 @@ class Certificate
   attr_reader :consultation, :options
 
   def patient
-    consultation.patient
+    PatientPresenter.new(consultation.patient)
   end
 
   def diagnosis
@@ -48,14 +48,18 @@ class Certificate
   end
 
   def consultations
-    selected_consultations_ids = options.fetch(:consultations, '').split('_').map(&:to_i)
-    patient_consultations = patient.consultations.reverse
-
+    patient_consultations = patient.consultations.reverse.map do |c|
+      ConsultationPresenter.new(c)
+    end
     selected_consultations = patient_consultations.select do |c|
       selected_consultations_ids.include? c.id
     end
 
     first_consultation_id = patient_consultations.first.id
     selected_consultations.each { |c| c.head = c.id == first_consultation_id }
+  end
+
+  def selected_consultations_ids
+    options.fetch(:consultations, '').split('_').map(&:to_i)
   end
 end

--- a/spec/controllers/consultations_controller_spec.rb
+++ b/spec/controllers/consultations_controller_spec.rb
@@ -20,7 +20,7 @@ describe ConsultationsController do
     end
 
     it 'assigns @consultations' do
-      expect(assigns(:consultations)).to eq(patient.consultations)
+      expect(assigns(:consultations)).to be_a ConsultationsPresenter
     end
 
     it { is_expected.to render_template :index }

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -43,42 +43,4 @@ describe Consultation do
       end
     end
   end
-
-  describe '#date' do
-    it 'returns the consultation date' do
-      consultation = build(:consultation, created_at: '2016-01-15 11:15')
-      expect(consultation.date).to eq('2016-01-15')
-    end
-  end
-
-  describe '#time' do
-    it 'returns the consultation time' do
-      consultation = build(:consultation, created_at: '2016-01-15 11:15')
-      expect(consultation.time).to eq('11:15 AM')
-    end
-  end
-
-  describe '#pretty_date' do
-    it 'returns the formatted consultation date' do
-      consultation = build(:consultation, created_at: '2016-04-13 11:15')
-      expect(consultation.pretty_date).to eq('Abril 13 de 2016')
-    end
-  end
-
-  describe '#miscellaneous?' do
-    let(:consultation) { build(:consultation) }
-
-    context 'when miscellaneous is present' do
-      it 'returns true' do
-        consultation.miscellaneous = 'notes'
-        expect(consultation.miscellaneous?).to be_truthy
-      end
-    end
-
-    context 'when miscellaneous is not present' do
-      it 'returns false' do
-        expect(consultation.miscellaneous?).to be_falsey
-      end
-    end
-  end
 end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -71,35 +71,6 @@ describe Patient do
     end
   end
 
-  describe '#age' do
-    context 'when a patient has a birthdate' do
-      subject { build(:patient, birthdate: Date.new(2011, 12, 8)) }
-
-      it "calculates patient's age" do
-        Timecop.freeze(Date.new(2015, 10, 21)) do
-          expect(subject.age.years).to eq(3)
-        end
-      end
-    end
-
-    context "when a patient doesn't have a birthdate" do
-      subject { Patient.new }
-
-      it 'returns 0' do
-        Timecop.freeze(Date.new(2015, 10, 21)) do
-          expect(subject.age.years).to eq(0)
-        end
-      end
-    end
-  end
-
-  describe '#name' do
-    it "returns patient's full name" do
-      patient = build(:patient, first_name: 'Alice', last_name: 'Doe')
-      expect(patient.name).to eq('Doe Alice')
-    end
-  end
-
   describe '#anamnesis?' do
     let(:patient) { build(:patient) }
 

--- a/spec/presenters/consultation_presenter_spec.rb
+++ b/spec/presenters/consultation_presenter_spec.rb
@@ -1,0 +1,127 @@
+require 'i18n'
+require_relative '../../app/presenters/consultation_presenter'
+
+describe ConsultationPresenter do
+  describe '#date' do
+    it 'returns the consultation date' do
+      consultation = double(:consultation, created_at: DateTime.new(2016, 1, 15))
+      presenter = described_class.new(consultation)
+      expect(presenter.date).to eq('2016-01-15')
+    end
+  end
+
+  describe '#long_date' do
+    it 'returns the consultation date' do
+      consultation = double(:consultation, created_at: DateTime.new(2016, 1, 15))
+      presenter = described_class.new(consultation)
+      expect(presenter.long_date).to eq('Jan 15, 2016')
+    end
+  end
+
+  describe '#time' do
+    it 'returns the consultation time' do
+      consultation = double(:consultation,
+                            created_at: DateTime.new(2016, 1, 15, 11, 15, 0))
+      presenter = described_class.new(consultation)
+      expect(presenter.time).to eq('11:15 AM')
+    end
+  end
+
+  describe '#pretty_date' do
+    it 'returns the formatted consultation date' do
+      created_at = DateTime.new(2016, 4, 13)
+      consultation = double(:consultation, created_at: created_at)
+      presenter = described_class.new(consultation)
+      expect(I18n).to receive(:localize).with(created_at, format: '%B %d de %Y')
+      presenter.pretty_date
+    end
+  end
+
+  describe '#next_appointment_date' do
+    it "returns the consultation's next appointment date" do
+      consultation = double(:consultation, next_appointment: DateTime.new(2016, 1, 15))
+      presenter = described_class.new(consultation)
+      expect(presenter.next_appointment_date).to eq('2016-01-15')
+    end
+  end
+
+  describe '#next_appointment_long_date' do
+    it "returns the consultation's next appointment date" do
+      consultation = double(:consultation, next_appointment: DateTime.new(2016, 1, 15))
+      presenter = described_class.new(consultation)
+      expect(presenter.next_appointment_long_date).to eq('Jan 15, 2016')
+    end
+  end
+
+  describe '#next_appointment?' do
+    context 'when there is next_appointment' do
+      it 'returns true' do
+        consultation = double(:consultation, next_appointment: double)
+        presenter = described_class.new(consultation)
+        expect(presenter.next_appointment?).to be_truthy
+      end
+    end
+
+    context 'when there is no next_appointment' do
+      it 'returns false' do
+        consultation = double(:consultation, next_appointment: nil)
+        presenter = described_class.new(consultation)
+        expect(presenter.next_appointment?).to be_falsey
+      end
+    end
+  end
+
+  describe '#diagnoses?' do
+    context 'when there are diagnoses' do
+      it 'returns true' do
+        consultation = double(:consultation, diagnoses: [double])
+        presenter = described_class.new(consultation)
+        expect(presenter.diagnoses?).to be_truthy
+      end
+    end
+
+    context 'when there are no diagnoses' do
+      it 'returns false' do
+        consultation = double(:consultation, diagnoses: [])
+        presenter = described_class.new(consultation)
+        expect(presenter.diagnoses?).to be_falsey
+      end
+    end
+  end
+
+  describe '#prescriptions?' do
+    context 'when there are prescriptions' do
+      it 'returns true' do
+        consultation = double(:consultation, prescriptions: [double])
+        presenter = described_class.new(consultation)
+        expect(presenter.prescriptions?).to be_truthy
+      end
+    end
+
+    context 'when there are no prescriptions' do
+      it 'returns false' do
+        consultation = double(:consultation, prescriptions: [])
+        presenter = described_class.new(consultation)
+        expect(presenter.prescriptions?).to be_falsey
+      end
+    end
+  end
+
+  describe '#miscellaneous?' do
+    context 'when miscellaneous is present' do
+      it 'returns true' do
+        consultation = double(:consultation, miscellaneous: 'extra notes')
+        presenter = described_class.new(consultation)
+        expect(presenter.miscellaneous?).to be_truthy
+      end
+    end
+
+    context 'when miscellaneous is not present' do
+      it 'returns false' do
+        consultation = double(:consultation, miscellaneous: nil)
+        presenter = described_class.new(consultation)
+        expect(presenter.miscellaneous?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/presenters/patient_presenter_spec.rb
+++ b/spec/presenters/patient_presenter_spec.rb
@@ -1,12 +1,14 @@
+require 'timecop'
 require_relative '../../app/presenters/patient_presenter'
+require_relative '../../lib/age_calculator'
 
 describe PatientPresenter do
-  describe '.formatted_birthdate' do
+  describe '#formatted_birthdate' do
     context 'when the patient is new' do
       it 'returns an empty string' do
         patient = double(:patient, new_record?: true)
-        patient_presenter = described_class.new(patient)
-        expect(patient_presenter.formatted_birthdate).to be_empty
+        presenter = described_class.new(patient)
+        expect(presenter.formatted_birthdate).to be_empty
       end
     end
 
@@ -14,8 +16,44 @@ describe PatientPresenter do
       it 'returns a formatted date' do
         patient = double(:patient, new_record?: false,
                                    birthdate: Date.new(2017, 7, 12))
-        patient_presenter = described_class.new(patient)
-        expect(patient_presenter.formatted_birthdate).to eq('2017-07-12')
+        presenter = described_class.new(patient)
+        expect(presenter.formatted_birthdate).to eq('2017-07-12')
+      end
+    end
+  end
+
+  describe '#name' do
+    it "returns patient's full name" do
+      patient = double(:patient, first_name: 'Alice', last_name: 'Doe')
+      presenter = described_class.new(patient)
+      expect(presenter.name).to eq('Doe Alice')
+    end
+  end
+
+  describe '#age' do
+    context 'when the patient has a birthdate' do
+      subject(:presenter) do
+        patient = double(:patient, birthdate: Date.new(2011, 12, 8))
+        described_class.new(patient)
+      end
+
+      it 'returns their age' do
+        Timecop.freeze(Date.new(2015, 10, 21)) do
+          expect(presenter.age.years).to eq(3)
+        end
+      end
+    end
+
+    context "when the patient doesn't have a birthdate" do
+      subject(:presenter) do
+        patient = double(:patient, birthdate: nil)
+        described_class.new(patient)
+      end
+
+      it 'returns 0' do
+        Timecop.freeze(Date.new(2015, 10, 21)) do
+          expect(presenter.age.years).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
The goal of this pull request is to clean up the models by moving the presentation logic to the corresponding presenters. SRP for the win!

**TODO**
- [x] Patient model
- [x] Consultation model
- [x] Clean up the views