### PR TITLE
Require CSV dependency explicitly

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class Patient < ApplicationRecord
   ATTRIBUTE_WHITELIST = [
     :medical_history,


### PR DESCRIPTION
Without requiring the CSV dependency the exporting operation fails.

```
NameError (uninitialized constant #<Class:0x000055a3d33dcfd0>::CSV)
```